### PR TITLE
[Kan-5] Create Docker Container for Pruju Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as the base image
+FROM python:3.10.6
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed dependencies specified in requirements.txt
+RUN pip install -r requirements.txt
+
+# Make port 80 available to the world outside this container
+EXPOSE 7860
+
+# Run app.py when the container launches
+CMD ["gradio", "app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10.6
 WORKDIR /app
 
 # Copy the current directory contents into the container at /app
-COPY . /app
+COPY requirements.txt /app
 
 # Install any needed dependencies specified in requirements.txt
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -72,15 +72,27 @@ MODEL_NAME="mistral"
 
 In the case of Ollama, you need to  install Ollama and run `ollama serve <modelname>` to serve the model to `127.0.0.1:11434`. Only Mistral 7B has been tested so far. The basic functionality works, but is not extensively tested.
 
-# Launch the app
+# Launch the app on Local Machine
 
 Run:
 
 ```bash
 gradio app.py
 ```
-
 Once the app is running, it will tell you the address where you can find the chatbot interface.
+
+# Launch the app in Docker Container
+
+1. Navigate to the root folder of the application where the Dockerfile is located.
+2. Build a Pruju Image
+    ```bash
+    docker build -t pruju-app .
+    ```
+3. Run the Docker Container
+    ```bash
+    docker run -p 7860:7860 -v "$(pwd)":/app pruju-app
+    ```
+4. View the app by navigating to http://localhost:7860/ in your browser.
 
 # Bring your own course materials
 

--- a/chat_caller.py
+++ b/chat_caller.py
@@ -13,8 +13,6 @@ import httpx
 from dotenv import load_dotenv 
 load_dotenv()
 isDocker = os.path.exists("/.dockerenv")
-if isDocker:
-    os.environ["CHAT_DATA_FOLDER"] = "/"+os.getenv("CHAT_DATA_FOLDER")
 
 from chat_utils import purge_memory, token_counter
 


### PR DESCRIPTION
Added a Dockerfile to run Pruju in a docker container.

This update allows the user to mount their local working directory as a volume so that:
1. They can make changes in their local without inspecting the container or remotely connecting to the container
2. They can commit and use Github desktop on their local machine.